### PR TITLE
[RS-1263] Don't use contentOffset due to incorrect offset calculation

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -47,7 +47,6 @@ type Props<T> = SceneRendererProps<T> & {
 type State = {|
   visibility: Animated.Value,
   scrollAmount: Animated.Value,
-  initialOffset: ?{| x: number, y: number |},
 |};
 
 const useNativeDriver = Boolean(NativeModules.NativeAnimatedModule);
@@ -93,21 +92,9 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
       }
     }
 
-    const initialOffset =
-      this.props.scrollEnabled && this.props.layout.width
-        ? {
-            x: this._getScrollAmount(
-              this.props,
-              this.props.navigationState.index
-            ),
-            y: 0,
-          }
-        : undefined;
-
     this.state = {
       visibility: new Animated.Value(initialVisibility),
       scrollAmount: new Animated.Value(0),
-      initialOffset,
     };
   }
 
@@ -408,7 +395,6 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
             onScrollEndDrag={this._handleEndDrag}
             onMomentumScrollBegin={this._handleMomentumScrollBegin}
             onMomentumScrollEnd={this._handleMomentumScrollEnd}
-            contentOffset={this.state.initialOffset}
             ref={el => (this._scrollView = el && el.getNode())}
           >
             {routes.map((route, i) => {


### PR DESCRIPTION
## Summary
- 탭이 스크롤이 되는 경우 초기 indicator의 위치를 제대로 찾지 못해서 보이지 않거나 엉뚱한 위치에 존재하는 버그 수정
- contentOffset과 충돌로 인해 해당 속성 제거
- 향후 근본적인 원인을 수정 필요함

## Related Issue
https://radish.atlassian.net/browse/RS-1263